### PR TITLE
Added Dockerfile for Application Packaging and Deployment

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -1,0 +1,38 @@
+# Step 1 - Use an official Python runtime as a parent image. You can use `python:3.8-slim`.
+FROM python:3.8-slim-buster
+# Step 2 - Set the working directory in the container
+WORKDIR /app
+# Step 3 Copy the application files in the container
+COPY . /app
+# Install system dependencies and ODBC driver 
+RUN if grep -q 'VERSION_ID="22.04"' /etc/os-release; then \
+    apt-get update && apt-get install -y \
+    unixodbc unixodbc-dev odbcinst odbcinst1debian2 libpq-dev gcc && \
+    curl -sS https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor | tee /etc/apt/trusted.gpg.d/mssql.gpg > /dev/null && \
+    curl https://packages.microsoft.com/config/ubuntu/22.04/prod.list > /etc/apt/sources.list.d/mssql-release.list && \
+    sudo apt-get update && \
+    ACCEPT_EULA=Y sudo apt-get install -y msodbcsql18; \
+else \
+    apt-get update && apt-get install -y \
+    unixodbc unixodbc-dev odbcinst odbcinst1debian2 libpq-dev gcc && \
+    apt-get install -y gnupg && \
+    apt-get install -y wget && \
+    wget -qO- https://packages.microsoft.com/keys/microsoft.asc | apt-key add - && \
+    wget -qO- https://packages.microsoft.com/config/debian/10/prod.list > /etc/apt/sources.list.d/mssql-release.list && \
+    apt-get update && \
+    ACCEPT_EULA=Y apt-get install -y msodbcsql18 && \
+    apt-get purge -y --auto-remove wget && \  
+    apt-get clean; \
+fi
+
+# Install pip and setuptools
+RUN pip install --upgrade pip setuptools
+
+# Step 4 - Install Python packages specified in requirements.txt
+RUN pip install --trusted-host pypi.python.org -r requirements.txt
+
+# Step 5 - Expose port 
+EXPOSE 5000
+
+# Step 6 - Define Startup Command
+CMD ["python", "app.py"]


### PR DESCRIPTION
In this pull request, I have added a Dockerfile that encapsulates all necessary dependencies and configuration settings for our application. This will ensure consistent packaging of the application and simplify its deployment process.

The Dockerfile includes instructions for:

- Selecting an official Python runtime as the parent image.
- Setting the working directory in the container to `/app`.
- Copying the contents of the local directory into the container's `/app` directory.
- Installing Python packages specified in the `requirements.txt` file.
- Exposing port 5000 to make the Flask application accessible from outside the container.
- Defining the startup command that runs the Flask application when the container launches.

Please review the changes and provide your feedback.